### PR TITLE
Fix/t2v routing video support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ print(resp.json())
 
 # Check per-worker health and load
 resp = requests.get(f"{ROUTER}/health_workers")
-# {'workers': [{'url': 'http://localhost:30000', 'active_requests': 0, 'is_dead': False, 'consecutive_failures': 0}, {'url': 'http://localhost:30002', 'active_requests': 0, 'is_dead': False, 'consecutive_failures': 0}]}
+# {'workers': [{'url': 'http://localhost:30000', 'active_requests': 0, 'is_dead': False, 'consecutive_failures': 0, 'video_support': False}, {'url': 'http://localhost:30002', 'active_requests': 0, 'is_dead': False, 'consecutive_failures': 0, 'video_support': True}]}
 print(resp.json())
 
 # Update weights from disk
 resp = requests.post(f"{ROUTER}/update_weights_from_disk", json={
     "model_path": "Qwen/Qwen-Image-2512",
 })
-# {'results': [{'worker_url': 'http://localhost:30000', 'status_code': 200, 'body': {'success': True, 'message': 'Updated 3 modules (text_encoder, vae, transformer).'}}]}
+# {'results': [{'worker_url': 'http://localhost:30000', 'status_code': 200, 'body': {'success': True, 'message': 'Updated 3 modules (text_encoder, vae, transformer).'}}, {'worker_url': 'http://localhost:30002', 'status_code': 502, 'body': {'error': ''}}]}
 print(resp.json())
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ CUDA_VISIBLE_DEVICES=0 sglang serve \
 
 # worker 2
 CUDA_VISIBLE_DEVICES=1 sglang serve \
-    --model-path Qwen/Qwen-Image \
+    --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
     --num-gpus 1 \
     --host 127.0.0.1 \
     --port 30002
@@ -76,13 +76,15 @@ ROUTER = "http://localhost:30081"
 
 # Check router health
 resp = requests.get(f"{ROUTER}/health")
+# {'status': 'healthy', 'healthy_workers': 2, 'total_workers': 2}
 print(resp.json())
 
 # List registered workers
 resp = requests.get(f"{ROUTER}/list_workers")
+# {'urls': ['http://localhost:30000', 'http://localhost:30002']}
 print(resp.json())
 
-# Image generation request (returns base64-encoded image)
+# Image generation request (image will be saved to outputs/)
 resp = requests.post(f"{ROUTER}/generate", json={
     "model": "Qwen/Qwen-Image",
     "prompt": "a cute cat",
@@ -90,29 +92,27 @@ resp = requests.post(f"{ROUTER}/generate", json={
     "response_format": "b64_json",
 })
 data = resp.json()
-print(data)
+# dict_keys(['id', 'created', 'data', 'peak_memory_mb', 'inference_time_s'])
+print(data.keys())
 
-# Decode and save the image locally
-img = base64.b64decode(data["data"][0]["b64_json"])
-with open("output.png", "wb") as f:
-    f.write(img)
-print("Saved to output.png")
-
-# Video generation request
+# Video generation request (Video will be saved to outputs/)
 resp = requests.post(f"{ROUTER}/generate_video", json={
-    "model": "Qwen/Qwen-Image",
+    "model": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
     "prompt": "a flowing river",
 })
+# {'id': '8286716d-7ef9-43ce-a3af-ce443543d221', 'object': 'video', 'model': 'Wan-AI/Wan2.1-T2V-1.3B-Diffusers', 'status': 'queued', 'progress': 0, 'created_at': 1771877888, 'size': '832x480', 'seconds': '6', 'quality': 'standard', 'url': None, 'remixed_from_video_id': None, 'completed_at': None, 'expires_at': None, 'error': None, 'file_path': './sglang-diffusion-routing/outputs/8286716d-7ef9-43ce-a3af-ce443543d221.mp4', 'peak_memory_mb': None, 'inference_time_s': None}
 print(resp.json())
 
 # Check per-worker health and load
 resp = requests.get(f"{ROUTER}/health_workers")
+# {'workers': [{'url': 'http://localhost:30000', 'active_requests': 0, 'is_dead': False, 'consecutive_failures': 0}, {'url': 'http://localhost:30002', 'active_requests': 0, 'is_dead': False, 'consecutive_failures': 0}]}
 print(resp.json())
 
 # Update weights from disk
 resp = requests.post(f"{ROUTER}/update_weights_from_disk", json={
     "model_path": "Qwen/Qwen-Image-2512",
 })
+# {'results': [{'worker_url': 'http://localhost:30000', 'status_code': 200, 'body': {'success': True, 'message': 'Updated 3 modules (text_encoder, vae, transformer).'}}]}
 print(resp.json())
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pytest>=9.0.2",
     "omegaconf>=2.3",
     "uvicorn>=0.30",
+    "pre-commit>=4.5.1",
 ]
 classifiers = [
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = { text = "MIT" }
 dependencies = [
     "fastapi>=0.110",
     "httpx>=0.27",
+    "pytest>=9.0.2",
     "uvicorn>=0.30",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,6 @@ sglang-d-router = "sglang_diffusion_routing.cli.main:main"
 test = [
     "pytest",
     "PyYAML",
-]
-dev = [
     "pre-commit>=4.5.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,8 @@ license = { text = "MIT" }
 dependencies = [
     "fastapi>=0.110",
     "httpx>=0.27",
-    "pytest>=9.0.2",
     "omegaconf>=2.3",
     "uvicorn>=0.30",
-    "pre-commit>=4.5.1",
 ]
 classifiers = [
     "License :: OSI Approved :: MIT License",
@@ -33,6 +31,9 @@ sglang-d-router = "sglang_diffusion_routing.cli.main:main"
 test = [
     "pytest",
     "PyYAML",
+]
+dev = [
+    "pre-commit>=4.5.1",
 ]
 
 [tool.setuptools]

--- a/src/sglang_diffusion_routing/router/diffusion_router.py
+++ b/src/sglang_diffusion_routing/router/diffusion_router.py
@@ -382,7 +382,7 @@ class DiffusionRouter:
         candidate_workers = [
             worker_url
             for worker_url, support in self.worker_video_support.items()
-            if not support
+            if support is not None and not support
         ]
 
         if not candidate_workers:

--- a/src/sglang_diffusion_routing/router/diffusion_router.py
+++ b/src/sglang_diffusion_routing/router/diffusion_router.py
@@ -566,7 +566,7 @@ class DiffusionRouter:
             and worker_url not in self.dead_workers
         ]
 
-        if self.worker_request_counts and not candidate_workers:
+        if not candidate_workers:
             return JSONResponse(
                 status_code=400,
                 content={

--- a/src/sglang_diffusion_routing/router/diffusion_router.py
+++ b/src/sglang_diffusion_routing/router/diffusion_router.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 _METADATA_HOSTS = {"169.254.169.254", "metadata.google.internal"}
 _IMAGE_TASK_TYPES = {"T2I", "I2I", "TI2I"}
+_VIDEO_TASK_TYPES = {"T2V"}
 
 
 class DiffusionRouter:
@@ -33,9 +34,8 @@ class DiffusionRouter:
         self.worker_request_counts: dict[str, int] = {}
         # URL -> consecutive health check failures
         self.worker_failure_counts: dict[str, int] = {}
-        # URL -> whether worker supports video generation
-        # True: supports, False: image-only, None: unknown/unprobed
-        self.worker_video_support: dict[str, bool | None] = {}
+        # URL -> task_type string (e.g. "T2I", "T2V"), or None if unprobed
+        self.worker_task_type: dict[str, str | None] = {}
         # quarantined workers excluded from routing
         self.dead_workers: set[str] = set()
         # video_id -> worker URL mapping for stable query routing
@@ -337,8 +337,8 @@ class DiffusionRouter:
         if video_id:
             self.video_job_to_worker[video_id] = worker_url
 
-    async def _probe_worker_video_support(self, worker_url: str) -> bool | None:
-        """Probe /v1/models and infer if this worker supports video generation."""
+    async def _probe_worker_task_type(self, worker_url: str) -> str | None:
+        """Probe /v1/models and return the task_type string for this worker."""
         try:
             response = await self.client.get(f"{worker_url}/v1/models", timeout=5.0)
             if response.status_code == 200:
@@ -350,13 +350,14 @@ class DiffusionRouter:
                     else None
                 )
                 if isinstance(task_type, str):
-                    return task_type.upper() not in _IMAGE_TASK_TYPES
+                    return task_type
         except (httpx.RequestError, json.JSONDecodeError):
             return None
+        return None
 
-    async def refresh_worker_video_support(self, worker_url: str) -> None:
-        """Refresh cached video capability for a single worker."""
-        self.worker_video_support[worker_url] = await self._probe_worker_video_support(
+    async def refresh_worker_task_type(self, worker_url: str) -> None:
+        """Refresh cached task_type for a single worker."""
+        self.worker_task_type[worker_url] = await self._probe_worker_task_type(
             worker_url
         )
 
@@ -485,7 +486,7 @@ class DiffusionRouter:
             "active_requests": self.worker_request_counts.get(worker_url, 0),
             "is_dead": worker_url in self.dead_workers,
             "consecutive_failures": self.worker_failure_counts.get(worker_url, 0),
-            "video_support": self.worker_video_support.get(worker_url),
+            "task_type": self.worker_task_type.get(worker_url),
         }
 
     async def _extract_worker_url(
@@ -516,11 +517,14 @@ class DiffusionRouter:
         """Route image generation requests to worker /v1/images/generations."""
         candidate_workers = [
             worker_url
-            for worker_url, support in self.worker_video_support.items()
-            if support is not None and not support
+            for worker_url, task_type in self.worker_task_type.items()
+            if task_type is not None
+            and task_type.upper() in _IMAGE_TASK_TYPES
+            and worker_url in self.worker_request_counts
+            and worker_url not in self.dead_workers
         ]
 
-        if not candidate_workers:
+        if self.worker_request_counts and not candidate_workers:
             return JSONResponse(
                 status_code=400,
                 content={
@@ -528,12 +532,20 @@ class DiffusionRouter:
                 },
             )
         return await self._forward_to_worker(
-            request, "v1/images/generations", worker_urls=candidate_workers
+            request, "v1/images/generations", worker_urls=candidate_workers or None
         )
 
     async def generate_video(self, request: Request):
-        """Route video generation requests to worker /v1/videos."""
-        candidate_workers = self._video_capable_workers()
+        """Route video generation to /v1/videos."""
+        candidate_workers = [
+            worker_url
+            for worker_url, task_type in self.worker_task_type.items()
+            if task_type is not None
+            and task_type.upper() in _VIDEO_TASK_TYPES
+            and worker_url in self.worker_request_counts
+            and worker_url not in self.dead_workers
+        ]
+
         if not candidate_workers:
             return JSONResponse(
                 status_code=400,
@@ -555,8 +567,9 @@ class DiffusionRouter:
     def _video_capable_workers(self) -> list[str]:
         return [
             worker_url
-            for worker_url, support in self.worker_video_support.items()
-            if support
+            for worker_url, task_type in self.worker_task_type.items()
+            if task_type is not None
+            and task_type.upper() in _VIDEO_TASK_TYPES
             and worker_url in self.worker_request_counts
             and worker_url not in self.dead_workers
         ]
@@ -705,13 +718,14 @@ class DiffusionRouter:
         """Per-worker health and load information."""
         workers = []
         for url, count in self.worker_request_counts.items():
+            task_type = self.worker_task_type.get(url)
             workers.append(
                 {
                     "url": url,
                     "active_requests": count,
                     "is_dead": url in self.dead_workers,
                     "consecutive_failures": self.worker_failure_counts.get(url, 0),
-                    "video_support": self.worker_video_support.get(url),
+                    "task_type": task_type,
                 }
             )
         return JSONResponse(content={"workers": workers})
@@ -740,7 +754,7 @@ class DiffusionRouter:
         if normalized_url not in self.worker_request_counts:
             self.worker_request_counts[normalized_url] = 0
             self.worker_failure_counts[normalized_url] = 0
-            self.worker_video_support[normalized_url] = None
+            self.worker_task_type[normalized_url] = None
             if self.verbose:
                 print(f"[diffusion-router] Added new worker: {normalized_url}")
 
@@ -748,7 +762,7 @@ class DiffusionRouter:
         normalized_url = self.normalize_worker_url(url)
         self.worker_request_counts.pop(normalized_url, None)
         self.worker_failure_counts.pop(normalized_url, None)
-        self.worker_video_support.pop(normalized_url, None)
+        self.worker_task_type.pop(normalized_url, None)
         self.dead_workers.discard(normalized_url)
         stale_video_ids = [
             video_id
@@ -776,8 +790,7 @@ class DiffusionRouter:
             self.register_worker(normalized_url)
         except ValueError as exc:
             return JSONResponse(status_code=400, content={"error": str(exc)})
-
-        await self.refresh_worker_video_support(normalized_url)
+        await self.refresh_worker_task_type(worker_url)
         return JSONResponse(
             content={
                 "status": "success",
@@ -856,7 +869,7 @@ class DiffusionRouter:
             self.dead_workers.discard(worker_url)
 
         if payload.get("refresh_video_support") is True:
-            await self.refresh_worker_video_support(worker_url)
+            await self.refresh_worker_task_type(worker_url)
 
         return JSONResponse(
             content={

--- a/src/sglang_diffusion_routing/router/diffusion_router.py
+++ b/src/sglang_diffusion_routing/router/diffusion_router.py
@@ -568,7 +568,7 @@ class DiffusionRouter:
 
         if not candidate_workers:
             return JSONResponse(
-                status_code=400,
+                status_code=503,
                 content={
                     "error": "No image-capable workers available in current worker pool.",
                 },
@@ -595,7 +595,7 @@ class DiffusionRouter:
 
         if not candidate_workers:
             return JSONResponse(
-                status_code=400,
+                status_code=503,
                 content={
                     "error": "No video-capable workers available in current worker pool.",
                 },

--- a/src/sglang_diffusion_routing/router/diffusion_router.py
+++ b/src/sglang_diffusion_routing/router/diffusion_router.py
@@ -93,11 +93,11 @@ class DiffusionRouter:
     async def _start_background_health_check(self) -> None:
         # Probe capability for pre-registered workers in the active server loop.
         unknown_workers = [
-            url for url, support in self.worker_video_support.items() if support is None
+            url for url, task_type in self.worker_task_type.items() if task_type is None
         ]
         if unknown_workers:
             await asyncio.gather(
-                *(self.refresh_worker_video_support(url) for url in unknown_workers),
+                *(self.refresh_worker_task_type(url) for url in unknown_workers),
                 return_exceptions=True,
             )
 
@@ -371,7 +371,7 @@ class DiffusionRouter:
                     else None
                 )
                 if isinstance(task_type, str):
-                    return task_type.upper() not in _IMAGE_TASK_TYPES
+                    return task_type.upper()
         except (httpx.RequestError, json.JSONDecodeError) as exc:
             logger.debug(
                 "[diffusion-router] video support probe failed: worker=%s error=%s",
@@ -379,6 +379,7 @@ class DiffusionRouter:
                 exc,
             )
             return None
+        return None
 
     async def refresh_worker_task_type(self, worker_url: str) -> None:
         """Refresh cached task_type for a single worker."""
@@ -589,6 +590,7 @@ class DiffusionRouter:
             and task_type.upper() in _VIDEO_TASK_TYPES
             and worker_url in self.worker_request_counts
             and worker_url not in self.dead_workers
+            and worker_url not in self.sleeping_workers
         ]
 
         if not candidate_workers:
@@ -763,22 +765,6 @@ class DiffusionRouter:
             },
         )
 
-    async def health_workers(self, request: Request):
-        """Per-worker health and load information."""
-        workers = []
-        for url, count in self.worker_request_counts.items():
-            task_type = self.worker_task_type.get(url)
-            workers.append(
-                {
-                    "url": url,
-                    "active_requests": count,
-                    "is_dead": url in self.dead_workers,
-                    "consecutive_failures": self.worker_failure_counts.get(url, 0),
-                    "task_type": task_type,
-                }
-            )
-        return JSONResponse(content={"workers": workers})
-
     async def update_weights_from_disk(self, request: Request):
         """Broadcast weight reload to all healthy workers."""
         healthy_workers = [
@@ -951,7 +937,7 @@ class DiffusionRouter:
                 content={"error": "Request body must be a JSON object"},
             )
 
-        allowed_fields = {"is_dead", "refresh_video_support"}
+        allowed_fields = {"is_dead", "refresh_task_type"}
         unknown_fields = sorted(set(payload) - allowed_fields)
         if unknown_fields:
             return JSONResponse(
@@ -962,7 +948,7 @@ class DiffusionRouter:
             return JSONResponse(
                 status_code=400,
                 content={
-                    "error": "At least one field is required: is_dead, refresh_video_support"
+                    "error": "At least one field is required: is_dead, refresh_task_type"
                 },
             )
 
@@ -970,12 +956,12 @@ class DiffusionRouter:
             return JSONResponse(
                 status_code=400, content={"error": "is_dead must be a boolean"}
             )
-        if "refresh_video_support" in payload and not isinstance(
-            payload["refresh_video_support"], bool
+        if "refresh_task_type" in payload and not isinstance(
+            payload["refresh_task_type"], bool
         ):
             return JSONResponse(
                 status_code=400,
-                content={"error": "refresh_video_support must be a boolean"},
+                content={"error": "refresh_task_type must be a boolean"},
             )
 
         if payload.get("is_dead") is True:
@@ -983,7 +969,7 @@ class DiffusionRouter:
         elif payload.get("is_dead") is False:
             self.dead_workers.discard(worker_url)
 
-        if payload.get("refresh_video_support") is True:
+        if payload.get("refresh_task_type") is True:
             await self.refresh_worker_task_type(worker_url)
 
         return JSONResponse(

--- a/tests/integration/common.py
+++ b/tests/integration/common.py
@@ -143,9 +143,25 @@ class FakeWorker:
 def fake_workers():
     workers, procs = [], []
     for i in range(2):
-        proc, url = _start_worker(f"worker-{i}")
+        proc, url = _start_worker(f"worker-{i}", task_type="T2I")
         procs.append(proc)
         workers.append(FakeWorker(proc, url, f"worker-{i}"))
+    for w in workers:
+        _wait_healthy(w.url)
+    yield workers
+    for p in procs:
+        _kill_proc(p)
+
+
+@pytest.fixture(scope="module")
+def fake_mixed_workers():
+    """One T2I worker and one T2V worker."""
+    configs = [("mixed-t2i", "T2I"), ("mixed-t2v", "T2V")]
+    workers, procs = [], []
+    for worker_id, task_type in configs:
+        proc, url = _start_worker(worker_id, task_type=task_type)
+        procs.append(proc)
+        workers.append(FakeWorker(proc, url, worker_id))
     for w in workers:
         _wait_healthy(w.url)
     yield workers
@@ -157,6 +173,21 @@ def fake_workers():
 def router_url(fake_workers):
     proc, url = _start_router(
         [w.url for w in fake_workers], routing_algorithm="round-robin"
+    )
+    try:
+        _wait_healthy(url)
+    except TimeoutError:
+        _kill_proc(proc)
+        raise
+    yield url
+    _kill_proc(proc)
+
+
+@pytest.fixture(scope="module")
+def mixed_router_url(fake_mixed_workers):
+    """Router with one T2I and one T2V worker."""
+    proc, url = _start_router(
+        [w.url for w in fake_mixed_workers], routing_algorithm="round-robin"
     )
     try:
         _wait_healthy(url)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,5 @@
 """Pytest fixtures for integration tests."""
 
-from .common import fake_workers, router_url
+from .common import fake_mixed_workers, fake_workers, mixed_router_url, router_url
 
-__all__ = ["fake_workers", "router_url"]
+__all__ = ["fake_workers", "fake_mixed_workers", "router_url", "mixed_router_url"]

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -232,14 +232,14 @@ class TestImageGeneration:
         )
         assert r.json()["model"] == "my-custom-model"
 
-    def test_no_image_workers_400(self):
+    def test_no_image_workers_503(self):
         proc, rurl = _start_router([])
         try:
             _wait_responding(rurl)
             r = httpx.post(
                 f"{rurl}/v1/images/generations", json={"prompt": "t"}, timeout=5.0
             )
-            assert r.status_code == 400
+            assert r.status_code == 503
             assert "error" in r.json()
         finally:
             _kill_proc(proc)
@@ -266,12 +266,12 @@ class TestVideoGeneration:
         )
         assert r.json()["data"][0]["revised_prompt"] == prompt
 
-    def test_no_video_workers_400(self):
+    def test_no_video_workers_503(self):
         proc, rurl = _start_router([])
         try:
             _wait_responding(rurl)
             r = httpx.post(f"{rurl}/v1/videos", json={"prompt": "t"}, timeout=5.0)
-            assert r.status_code == 400
+            assert r.status_code == 503
             assert "video-capable" in r.json()["error"]
         finally:
             _kill_proc(proc)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -135,7 +135,7 @@ class TestWorkerRegistration:
 
     def test_dynamic_worker_receives_traffic(self, fake_workers):
         """Add a worker dynamically and verify it actually receives requests."""
-        w_proc, w_url = _start_worker("dynamic")
+        w_proc, w_url = _start_worker("dynamic", task_type="T2I")
         r_proc, rurl = _start_router([])
         try:
             _wait_healthy(w_url)
@@ -232,23 +232,23 @@ class TestImageGeneration:
         )
         assert r.json()["model"] == "my-custom-model"
 
-    def test_no_workers_503(self):
+    def test_no_image_workers_400(self):
         proc, rurl = _start_router([])
         try:
             _wait_responding(rurl)
             r = httpx.post(
                 f"{rurl}/v1/images/generations", json={"prompt": "t"}, timeout=5.0
             )
-            assert r.status_code == 503
+            assert r.status_code == 400
             assert "error" in r.json()
         finally:
             _kill_proc(proc)
 
 
 class TestVideoGeneration:
-    def test_generate_video(self, router_url):
+    def test_generate_video(self, mixed_router_url):
         r = httpx.post(
-            f"{router_url}/v1/videos",
+            f"{mixed_router_url}/v1/videos",
             json={"model": "vid-model", "prompt": "river"},
             timeout=10.0,
         )
@@ -257,16 +257,16 @@ class TestVideoGeneration:
         assert "url" in body["data"][0]
         assert "created" in body
 
-    def test_video_prompt_preserved(self, router_url):
+    def test_video_prompt_preserved(self, mixed_router_url):
         prompt = "a flowing river in autumn"
         r = httpx.post(
-            f"{router_url}/v1/videos",
+            f"{mixed_router_url}/v1/videos",
             json={"model": "vid", "prompt": prompt},
             timeout=10.0,
         )
         assert r.json()["data"][0]["revised_prompt"] == prompt
 
-    def test_no_workers_503(self):
+    def test_no_video_workers_400(self):
         proc, rurl = _start_router([])
         try:
             _wait_responding(rurl)

--- a/tests/integration/test_runtime.py
+++ b/tests/integration/test_runtime.py
@@ -55,8 +55,8 @@ class TestRoundRobinBalancing:
 
 class TestLeastRequestBalancing:
     def test_prefers_less_loaded_worker(self, fake_workers):
-        slow_proc, slow_url = _start_worker("slow", latency=0.3)
-        fast_proc, fast_url = _start_worker("fast", latency=0.0)
+        slow_proc, slow_url = _start_worker("slow", latency=0.3, task_type="T2I")
+        fast_proc, fast_url = _start_worker("fast", latency=0.0, task_type="T2I")
         r_proc, rurl = _start_router(
             [slow_url, fast_url],
             routing_algorithm="least-request",
@@ -89,19 +89,26 @@ class TestLeastRequestBalancing:
 
 class TestWorkerFailure:
     def test_unreachable_worker_502(self):
-        proc, rurl = _start_router(["http://127.0.0.1:1"])
+        w_proc, w_url = _start_worker("unreachable", task_type="T2I")
+        r_proc, rurl = _start_router([w_url])
         try:
-            _wait_responding(rurl)
+            _wait_healthy(w_url)
+            _wait_healthy(rurl)
+            # Kill the worker after the router has probed and cached task_type="T2I".
+            # The router still considers it an image candidate and attempts the
+            # connection, which now fails with 502.
+            _kill_proc(w_proc)
             r = httpx.post(
                 f"{rurl}/v1/images/generations", json={"prompt": "t"}, timeout=10.0
             )
             assert r.status_code == 502
             assert "error" in r.json()
         finally:
-            _kill_proc(proc)
+            _kill_proc(w_proc)
+            _kill_proc(r_proc)
 
     def test_worker_500_forwarded(self):
-        w_proc, w_url = _start_worker("failing", fail_rate=1.0)
+        w_proc, w_url = _start_worker("failing", fail_rate=1.0, task_type="T2I")
         r_proc, rurl = _start_router([w_url])
         try:
             _wait_healthy(w_url)
@@ -118,7 +125,7 @@ class TestWorkerFailure:
             _kill_proc(r_proc)
 
     def test_worker_killed_returns_502(self, fake_workers):
-        w_proc, w_url = _start_worker("ephemeral")
+        w_proc, w_url = _start_worker("ephemeral", task_type="T2I")
         r_proc, rurl = _start_router([w_url])
         try:
             _wait_healthy(w_url)
@@ -163,21 +170,21 @@ class TestConcurrency:
             assert "data" in body
             assert len(body["data"]) == 1
 
-    def test_concurrent_mixed_endpoints(self, router_url):
+    def test_concurrent_mixed_endpoints(self, mixed_router_url):
         def gen_image():
             return httpx.post(
-                f"{router_url}/v1/images/generations",
+                f"{mixed_router_url}/v1/images/generations",
                 json={"prompt": "img", "response_format": "b64_json"},
                 timeout=15.0,
             )
 
         def gen_video():
             return httpx.post(
-                f"{router_url}/v1/videos", json={"prompt": "vid"}, timeout=15.0
+                f"{mixed_router_url}/v1/videos", json={"prompt": "vid"}, timeout=15.0
             )
 
         def check_health():
-            return httpx.get(f"{router_url}/health", timeout=5.0)
+            return httpx.get(f"{mixed_router_url}/health", timeout=5.0)
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=6) as pool:
             futs = (

--- a/tests/unit/test_router_endpoints.py
+++ b/tests/unit/test_router_endpoints.py
@@ -45,6 +45,62 @@ def test_add_worker_rejects_blocked_metadata_host():
         assert "blocked" in response.json()["error"]
 
 
+def test_generate_routes_only_to_image_workers():
+    router = DiffusionRouter(make_router_args())
+    router.register_worker("http://image-worker:8000")
+    router.register_worker("http://video-worker:8000")
+    router.worker_video_support["http://image-worker:8000"] = False
+    router.worker_video_support["http://video-worker:8000"] = True
+
+    captured = {}
+
+    async def fake_forward(request, path, worker_urls=None):
+        captured["worker_urls"] = worker_urls
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(content={"ok": True})
+
+    router._forward_to_worker = fake_forward  # type: ignore[assignment]
+    with TestClient(router.app) as client:
+        client.post("/generate", json={"prompt": "a cat"})
+
+    assert captured["worker_urls"] == ["http://image-worker:8000"]
+
+
+def test_generate_includes_unknown_workers():
+    router = DiffusionRouter(make_router_args())
+    router.register_worker("http://unknown-worker:8000")
+    router.register_worker("http://video-worker:8000")
+    router.worker_video_support["http://unknown-worker:8000"] = None
+    router.worker_video_support["http://video-worker:8000"] = True
+
+    captured = {}
+
+    async def fake_forward(request, path, worker_urls=None):
+        captured["worker_urls"] = worker_urls
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(content={"ok": True})
+
+    router._forward_to_worker = fake_forward  # type: ignore[assignment]
+    with TestClient(router.app) as client:
+        client.post("/generate", json={"prompt": "a cat"})
+
+    assert captured["worker_urls"] == ["http://unknown-worker:8000"]
+
+
+def test_generate_returns_400_when_only_video_workers():
+    router = DiffusionRouter(make_router_args())
+    router.register_worker("http://video-worker:8000")
+    router.worker_video_support["http://video-worker:8000"] = True
+
+    with TestClient(router.app) as client:
+        response = client.post("/generate", json={"prompt": "a cat"})
+
+    assert response.status_code == 400
+    assert "image-capable" in response.json()["error"]
+
+
 def test_update_weights_from_disk_returns_broadcast_results():
     router = DiffusionRouter(make_router_args())
     router.register_worker("http://localhost:10090")

--- a/tests/unit/test_router_endpoints.py
+++ b/tests/unit/test_router_endpoints.py
@@ -25,9 +25,9 @@ def test_post_workers_normalizes_and_deduplicates():
     router = DiffusionRouter(make_router_args())
 
     async def fake_refresh(worker_url: str):
-        router.worker_video_support[worker_url] = False
+        router.worker_task_type[worker_url] = "T2I"
 
-    router.refresh_worker_video_support = fake_refresh  # type: ignore[assignment]
+    router.refresh_worker_task_type = fake_refresh  # type: ignore[assignment]
     with TestClient(router.app) as client:
         first = client.post("/workers", params={"url": "http://LOCALHOST:10090/"})
         assert first.status_code == 200
@@ -44,7 +44,7 @@ def test_post_workers_normalizes_and_deduplicates():
         assert workers[0]["active_requests"] == 0
         assert workers[0]["is_dead"] is False
         assert workers[0]["consecutive_failures"] == 0
-        assert workers[0]["video_support"] is False
+        assert workers[0]["task_type"] == "T2I"
 
 
 def test_post_workers_rejects_blocked_metadata_host():
@@ -59,8 +59,8 @@ def test_generate_routes_only_to_image_workers():
     router = DiffusionRouter(make_router_args())
     router.register_worker("http://image-worker:8000")
     router.register_worker("http://video-worker:8000")
-    router.worker_video_support["http://image-worker:8000"] = False
-    router.worker_video_support["http://video-worker:8000"] = True
+    router.worker_task_type["http://image-worker:8000"] = "T2I"
+    router.worker_task_type["http://video-worker:8000"] = "T2V"
 
     captured = {}
 
@@ -72,7 +72,7 @@ def test_generate_routes_only_to_image_workers():
 
     router._forward_to_worker = fake_forward  # type: ignore[assignment]
     with TestClient(router.app) as client:
-        client.post("/generate", json={"prompt": "a cat"})
+        client.post("/v1/images/generations", json={"prompt": "a cat"})
 
     assert captured["worker_urls"] == ["http://image-worker:8000"]
 
@@ -80,10 +80,10 @@ def test_generate_routes_only_to_image_workers():
 def test_generate_returns_400_when_only_unknown_workers():
     router = DiffusionRouter(make_router_args())
     router.register_worker("http://unknown-worker:8000")
-    router.worker_video_support["http://unknown-worker:8000"] = None
+    router.worker_task_type["http://unknown-worker:8000"] = None
 
     with TestClient(router.app) as client:
-        response = client.post("/generate", json={"prompt": "a cat"})
+        response = client.post("/v1/images/generations", json={"prompt": "a cat"})
 
     assert response.status_code == 400
     assert "image-capable" in response.json()["error"]
@@ -92,25 +92,27 @@ def test_generate_returns_400_when_only_unknown_workers():
 def test_generate_returns_400_when_only_video_workers():
     router = DiffusionRouter(make_router_args())
     router.register_worker("http://video-worker:8000")
-    router.worker_video_support["http://video-worker:8000"] = True
+    router.worker_task_type["http://video-worker:8000"] = "T2V"
 
     with TestClient(router.app) as client:
-        response = client.post("/generate", json={"prompt": "a cat"})
+        response = client.post("/v1/images/generations", json={"prompt": "a cat"})
 
     assert response.status_code == 400
     assert "image-capable" in response.json()["error"]
+
+
 def test_get_worker_by_id_success_and_not_found():
     router = DiffusionRouter(make_router_args())
     worker_url = "http://localhost:10090"
     worker_id = quote(worker_url, safe="")
     router.register_worker(worker_url)
-    router.worker_video_support[worker_url] = True
+    router.worker_task_type[worker_url] = "T2V"
 
     with TestClient(router.app) as client:
         found = client.get(f"/workers/{worker_id}")
         assert found.status_code == 200
         assert found.json()["worker"]["url"] == worker_url
-        assert found.json()["worker"]["video_support"] is True
+        assert found.json()["worker"]["task_type"] == "T2V"
 
         missing = client.get(f"/workers/{quote('http://localhost:19999', safe='')}")
         assert missing.status_code == 404
@@ -121,14 +123,14 @@ def test_put_worker_updates_flags_and_refreshes_capability():
     worker_url = "http://localhost:10090"
     worker_id = quote(worker_url, safe="")
     router.register_worker(worker_url)
-    router.worker_video_support[worker_url] = None
+    router.worker_task_type[worker_url] = None
     refresh_calls: list[str] = []
 
     async def fake_refresh(url: str):
         refresh_calls.append(url)
-        router.worker_video_support[url] = True
+        router.worker_task_type[url] = "T2V"
 
-    router.refresh_worker_video_support = fake_refresh  # type: ignore[assignment]
+    router.refresh_worker_task_type = fake_refresh  # type: ignore[assignment]
     with TestClient(router.app) as client:
         response = client.put(
             f"/workers/{worker_id}",
@@ -137,7 +139,7 @@ def test_put_worker_updates_flags_and_refreshes_capability():
         assert response.status_code == 200
         assert refresh_calls == [worker_url]
         assert response.json()["worker"]["is_dead"] is True
-        assert response.json()["worker"]["video_support"] is True
+        assert response.json()["worker"]["task_type"] == "T2V"
 
         revive = client.put(f"/workers/{worker_id}", json={"is_dead": False})
         assert revive.status_code == 200
@@ -170,7 +172,7 @@ def test_delete_worker_removes_runtime_state():
     worker_id = quote(worker_url, safe="")
     router.register_worker(worker_url)
     router.worker_failure_counts[worker_url] = 2
-    router.worker_video_support[worker_url] = True
+    router.worker_task_type[worker_url] = "T2V"
     router.dead_workers.add(worker_url)
 
     with TestClient(router.app) as client:
@@ -178,7 +180,7 @@ def test_delete_worker_removes_runtime_state():
         assert deleted.status_code == 200
         assert worker_url not in router.worker_request_counts
         assert worker_url not in router.worker_failure_counts
-        assert worker_url not in router.worker_video_support
+        assert worker_url not in router.worker_task_type
         assert worker_url not in router.dead_workers
 
         missing = client.delete(f"/workers/{worker_id}")
@@ -206,7 +208,7 @@ def test_v1_images_generations_routes_to_image_path():
 def test_v1_videos_requires_video_capable_workers():
     router = DiffusionRouter(make_router_args())
     router.register_worker("http://localhost:10090")
-    router.worker_video_support["http://localhost:10090"] = False
+    router.worker_task_type["http://localhost:10090"] = "T2I"
 
     with TestClient(router.app) as client:
         response = client.post("/v1/videos", json={"prompt": "river"})
@@ -218,8 +220,8 @@ def test_v1_videos_routes_only_to_video_capable_workers_and_caches_video_id():
     router = DiffusionRouter(make_router_args())
     router.register_worker("http://localhost:10090")
     router.register_worker("http://localhost:10091")
-    router.worker_video_support["http://localhost:10090"] = True
-    router.worker_video_support["http://localhost:10091"] = False
+    router.worker_task_type["http://localhost:10090"] = "T2V"
+    router.worker_task_type["http://localhost:10091"] = "T2I"
     call_args: dict = {}
 
     async def fake_forward_selected_worker(request, path: str, worker_url: str):

--- a/tests/unit/test_router_endpoints.py
+++ b/tests/unit/test_router_endpoints.py
@@ -123,7 +123,7 @@ def test_put_worker_updates_flags_and_refreshes_capability():
     worker_url = "http://localhost:10090"
     worker_id = quote(worker_url, safe="")
     router.register_worker(worker_url)
-    router.worker_task_type[worker_url] = None
+    router.worker_task_type[worker_url] = "T2I"  # non-None so startup probe skips it
     refresh_calls: list[str] = []
 
     async def fake_refresh(url: str):
@@ -134,7 +134,7 @@ def test_put_worker_updates_flags_and_refreshes_capability():
     with TestClient(router.app) as client:
         response = client.put(
             f"/workers/{worker_id}",
-            json={"is_dead": True, "refresh_video_support": True},
+            json={"is_dead": True, "refresh_task_type": True},
         )
         assert response.status_code == 200
         assert refresh_calls == [worker_url]

--- a/tests/unit/test_router_endpoints.py
+++ b/tests/unit/test_router_endpoints.py
@@ -189,6 +189,8 @@ def test_delete_worker_removes_runtime_state():
 
 def test_v1_images_generations_routes_to_image_path():
     router = DiffusionRouter(make_router_args())
+    router.register_worker("http://image-worker:8000")
+    router.worker_task_type["http://image-worker:8000"] = "T2I"
     call_args: dict = {}
 
     async def fake_forward(request, path: str, worker_urls=None):
@@ -202,7 +204,7 @@ def test_v1_images_generations_routes_to_image_path():
         response = client.post("/v1/images/generations", json={"prompt": "cat"})
         assert response.status_code == 200
         assert call_args["path"] == "v1/images/generations"
-        assert call_args["worker_urls"] is None
+        assert call_args["worker_urls"] == ["http://image-worker:8000"]
 
 
 def test_v1_diffusion_generate_routes_to_diffusion_path():


### PR DESCRIPTION
## Motivation

When routing image generation to T2V worker with `Wan-AI/Wan2.1-T2V-1.3B-Diffusers` , the worker will go through video diffusion process and eventually error. 

## Modifications

1. Only route image generation to workers that are T2I. 
3. Update readme and make sure all example runs
4. bump the pinned sglang version so that upstream update_weight_from_disk api is enabled

## Benchmarking and Profiling

Expected outputs are updated in readme

## Checklist

- [x] Format your code with `pre-commit run --all-files`.
- [x] Add or update unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Provide accuracy and performance benchmark results if applicable.
- [ ] Ensure all CI checks pass.

## Review Process

1. Get approvals from maintainers and other reviewers.
5. Ensure all CI tests pass.
6. After green CI and required approvals, ask maintainers to merge.
